### PR TITLE
Fix: GitHub pages

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -27,6 +27,7 @@ const config: Config = {
   onBrokenMarkdownLinks: "throw",
 
   baseUrlIssueBanner: false,
+  trailingSlash: true,
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "launcher-docs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "launcher-docs",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@docusaurus/core": "3.7.0",
         "@docusaurus/preset-classic": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launcher-docs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+docs.godotlauncher.org


### PR DESCRIPTION
This pull request includes several changes to the configuration and versioning of the documentation site. The most important changes include enabling trailing slashes in URLs, updating the package version, and adding a custom domain.

Configuration updates:

* [`docusaurus.config.ts`](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R30): Enabled trailing slashes in URLs by setting `trailingSlash` to `true`.

Version updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `1.1.0` to `1.1.1`.

Custom domain:

* [`static/CNAME`](diffhunk://#diff-2c4a30f75313bfde8fc686962da9205016ab78ea92e193422b8c5a20a361de5dR1): Added a custom domain `docs.godotlauncher.org`.