### PR TITLE
Fix font import in css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "launcher-docs",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "launcher-docs",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@docusaurus/core": "3.7.0",
         "@docusaurus/preset-classic": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launcher-docs",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&display=swap');
 
 /**
  * Any CSS included here will be global. The classic template


### PR DESCRIPTION
This pull request includes a version update and a change to the CSS file to use a different font.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `1.1.1` to `1.1.2`.

CSS changes:

* [`src/css/custom.css`](diffhunk://#diff-44813f307e729042af7e70beff6f32ea63a7941bc100043a49e84d229ea2570fL1-R1): Changed the imported font from 'Noto Sans' to 'Nunito Sans'.