### PR TITLE
Fix: Page paths

### DIFF
--- a/docs/guides/launch-godot-project-in-windowed-mode.md
+++ b/docs/guides/launch-godot-project-in-windowed-mode.md
@@ -60,8 +60,8 @@ For **Godot 4.4 and newer**, you may want to leave this off and let the editor r
 ## Related
 
 - [Download Godot Launcher](https://godotlauncher.org/download/)
-- [Project Badges and Tooltips](../project-badges/)
-- [Managing Godot Editor Versions](../change-project-editor/)
+- [Project Badges and Tooltips](/project-badges/)
+- [Managing Godot Editor Versions](/guides/change-project-editor/)
 
 ---
 

--- a/docs/project-badges.md
+++ b/docs/project-badges.md
@@ -2,7 +2,7 @@
 id: project-badges
 title: "Project Badges and Tooltips"
 description: "Understand what each badge means in the Godot Launcher project list and how they help identify project types at a glance."
-slug: "/guides/project-badges"
+slug: "/project-badges"
 tags:
   - guides
   - godot
@@ -68,8 +68,8 @@ Badges improve workflow clarity and reduce configuration guesswork. They are esp
 
 ## Related Documentation
 
-- [Launch Godot Project in Windowed Mode](../launch-godot-project-in-windowed-mode/)
-- [Managing Godot Editor Versions](../change-project-editor/)
+- [Launch Godot Project in Windowed Mode](/guides/launch-godot-project-in-windowed-mode/)
+- [Managing Godot Editor Versions](/guides/change-project-editor/)
 - [Download Godot Launcher](https://godotlauncher.org/download/)
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "launcher-docs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "launcher-docs",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@docusaurus/core": "3.7.0",
         "@docusaurus/preset-classic": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "launcher-docs",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -9,7 +9,7 @@
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
-    "serve": "docusaurus serve",
+    "serve": "docusaurus serve -p 3001",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc"


### PR DESCRIPTION
This pull request includes updates to documentation links for consistency and accuracy, as well as minor adjustments to the `package.json` file to improve the development experience. Below are the key changes:

### Documentation Updates:
* Updated relative links to absolute paths in `docs/guides/launch-godot-project-in-windowed-mode.md` for better navigation. (`[docs/guides/launch-godot-project-in-windowed-mode.mdL63-R64](diffhunk://#diff-fe69de26c88fae073fbd05ed48b35544ae5643b59b78c0d14f7e4be85f966828L63-R64)`)
* Adjusted the `slug` field in `docs/project-badges.md` to match the updated absolute path format. (`[docs/project-badges.mdL5-R5](diffhunk://#diff-614ce9b5000214c970ff8c83deac1fcf649e4fd19c3792f626ae36c162c3c7acL5-R5)`)
* Updated related documentation links in `docs/project-badges.md` to use absolute paths for consistency. (`[docs/project-badges.mdL71-R72](diffhunk://#diff-614ce9b5000214c970ff8c83deac1fcf649e4fd19c3792f626ae36c162c3c7acL71-R72)`)

### `package.json` Modifications:
* Bumped the version of the project from `1.2.0` to `1.2.1` to reflect the changes. (`[package.jsonL3-R3](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)`)
* Modified the `serve` script to specify port `3001` for local development. (`[package.jsonL12-R12](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L12-R12)`)