### PR TITLE
Fix: styles and fonts

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -43,7 +43,7 @@
 
 html {
   scroll-behavior: smooth;
-  font-family: "Noto Sans", sans-serif;
+  font-family: "Nunito Sans", sans-serif;
   /* font-size: 18px; */
 }
 

--- a/src/theme/Footer/Copyright/index.module.css
+++ b/src/theme/Footer/Copyright/index.module.css
@@ -1,5 +1,5 @@
 .copyright {
-  font-size: 1.2rem;
+  font-size: 0.9rem;
   text-align: left;
 
   display: flex;
@@ -21,8 +21,8 @@
 }
 
 .disclaimer {
-  font-size: 1rem;
-  opacity: 0.8;
+  font-size: 0.9rem;
+  opacity: 0.6;
   text-align: left;
 
 }


### PR DESCRIPTION
This pull request introduces minor visual adjustments to the site's typography and footer styling. The changes focus on updating the font family used throughout the site and refining the appearance of copyright and disclaimer text in the footer.

Typography updates:

* Changed the global font family in `custom.css` from `"Noto Sans"` to `"Nunito Sans"` for improved aesthetics and readability.

Footer styling refinements:

* Reduced the font size of the `.copyright` class in `index.module.css` from `1.2rem` to `0.9rem` for a more subtle appearance.
* Adjusted the `.disclaimer` class in `index.module.css` by decreasing the font size from `1rem` to `0.9rem` and lowering the opacity from `0.8` to `0.6` for better visual hierarchy.